### PR TITLE
Changed unit to component, removed xunit as a dependency.

### DIFF
--- a/tests/Component.Tests/ComponentTests.cs
+++ b/tests/Component.Tests/ComponentTests.cs
@@ -8,7 +8,7 @@ namespace Component.Tests
 {
 	public class ComponentTests
 	{
-		[Unit]
+		[Component]
 		public static void WhenServiceAddedThenCanResolveComponentSystem()
 		{
 			new ServiceCollection()
@@ -27,28 +27,28 @@ namespace Component.Tests
 			=> (provider ?? CreateProvider())
 				.GetRequiredService<ComponentSystem>();
 
-		[Unit]
+		[Component]
 		public static void WhenAssigningComponentToNullEntityThenReturnsFalse()
 		{
 			CreateTarget().Assign((object)null, new object())
 				.Should().BeFalse();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenAssigningNullComponentToEntityThenReturnsFalse()
 		{
 			CreateTarget().Assign(new object(), (object)null)
 				.Should().BeFalse();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenAssigningComponentToEntityThenReturnsTrue()
 		{
 			CreateTarget().Assign(new object(), new object())
 				.Should().BeTrue();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenAssigningSameComponentTypeToSameEntityInstanceThenReturnsFalse()
 		{
 			var entity = new object();
@@ -60,7 +60,7 @@ namespace Component.Tests
 				.Should().BeFalse();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenAssigningSameComponentsToDifferentEntityInstancesThenReturnsTrue()
 		{
 			var provider = CreateProvider();
@@ -71,21 +71,21 @@ namespace Component.Tests
 				.Should().BeTrue();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenRetrievingStateForEntityNeverAssignedToThenDoesNotThrowException()
 		{
 			Action act = () => CreateTarget().Get(new object());
 			act.ShouldNotThrow();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenRetrievingEntityStateForEntityNeverAssignedToThenReturnsNull()
 		{
 			CreateTarget().Get(new object())
 				.Should().BeNull();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenRetrievingComponentAssignedToSameEntityInstanceThenReturnsComponent()
 		{
 			var entity = new object();
@@ -97,7 +97,7 @@ namespace Component.Tests
 				.Should().Be(component);
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenRetrievingComponentAssignedToDifferentEntityInstanceThenReturnsDefaultComponent()
 		{
 			var target = CreateTarget();
@@ -107,21 +107,21 @@ namespace Component.Tests
 				.Should().Be(default(object));
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenUnassigningComponentFromNullEntityThenReturnsFalse()
 		{
 			CreateTarget().Unassign((object)null, new object())
 				.Should().BeFalse();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenUnassigningComponentNeverAssignedToEntityThenReturnsFalse()
 		{
 			CreateTarget().Unassign(new object(), new object())
 				.Should().BeFalse();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenUnassigningComponentOfSameTypeAsAssignedComponentThenReturnsTrue()
 		{
 			var entity = new object();
@@ -132,7 +132,7 @@ namespace Component.Tests
 				.Should().BeTrue();
 		}
 
-		[Unit]
+		[Component]
 		public static void WhenUnassigningUnassignedComponentThenReturnsFalse()
 		{
 			var entity = new object();

--- a/tests/Component.Tests/project.json
+++ b/tests/Component.Tests/project.json
@@ -12,7 +12,6 @@
 		"FluentAssertions": "4.0.0",
 		"Microsoft.Framework.DependencyInjection": "1.0.0-beta8",
 		"TestAttributes": "2.0.0-rc1",
-		"xunit": "2.1.0",
 		"xunit.runner.dnx": "2.1.0-beta6-build191"
 	},
 	"commands": {


### PR DESCRIPTION
Right, categories are running through the command line. Test explorer has nothing, which I've raised before.
